### PR TITLE
Add basic CW decoder with WAV streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: '6.1'
+    - uses: actions/checkout@v3
+    - name: Build
+      run: swift build --build-tests
+    - name: Test
+      run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/cw/AudioStreamer.swift
+++ b/Sources/cw/AudioStreamer.swift
@@ -12,17 +12,21 @@ public protocol AudioStreamSource {
     func stopStreaming()
 }
 
-/// Stream samples from an on–disk WAV file.  The entire file is loaded into
+/// Stream samples from an on–disk WAV file. The entire file is loaded into
 /// memory and every sample is forwarded to the callback.
 public final class FileStreamer: AudioStreamSource {
     private let fileURL: URL
 
     public init(filePath: String) throws {
-        self.fileURL = URL(fileURLWithPath: filePath)
-        if !FileManager.default.fileExists(atPath: fileURL.path) {
-            throw NSError(domain: "FileStreamer", code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "File not found"])
+        let url = URL(fileURLWithPath: filePath)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw NSError(
+                domain: "FileStreamer",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "File not found"]
+            )
         }
+        self.fileURL = url
     }
 
     public func startStreaming(_ onSample: ((Float) -> Void)?) throws {
@@ -53,12 +57,17 @@ public final class MacOSDeviceStreamer: AudioStreamSource {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
 
-        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                         sampleRate: 44100,
-                                         channels: 1,
-                                         interleaved: false) else {
-            throw NSError(domain: "MacOSDeviceStreamer", code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: "Failed to create audio format"])
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44100,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(
+                domain: "MacOSDeviceStreamer",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create audio format"]
+            )
         }
 
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
@@ -80,4 +89,3 @@ public final class MacOSDeviceStreamer: AudioStreamSource {
     }
 }
 #endif
-

--- a/Sources/cw/AudioStreamer.swift
+++ b/Sources/cw/AudioStreamer.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
 
 /// A minimal abstraction representing a source of audio samples.
 public protocol AudioStreamSource {
@@ -42,7 +45,6 @@ public final class FileStreamer: AudioStreamSource {
 }
 
 #if canImport(AVFoundation) && os(macOS)
-import AVFoundation
 
 /// Stream audio from a macOS audio input device.
 public final class MacOSDeviceStreamer: AudioStreamSource {
@@ -88,4 +90,6 @@ public final class MacOSDeviceStreamer: AudioStreamSource {
         audioEngine = nil
     }
 }
+
 #endif
+

--- a/Sources/cw/CWDecoder.swift
+++ b/Sources/cw/CWDecoder.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Decode Continuous Wave (Morse) audio streams into text.
+///
+/// This implementation is intentionally lightweight – it performs basic tone
+/// detection using the Goertzel algorithm, converts the resulting power
+/// envelope into keyed/unkeyed durations and finally maps the detected dot/dash
+/// sequences to characters.  It is sufficient for decoding the bundled test
+/// samples which contain relatively clean single‑frequency Morse recordings.
+public final class CWDecoder {
+    public init() {}
+
+    /// Decode a WAV file located at `path` and return the detected text.
+    public func decodeWAVFile(atPath path: String) throws -> String {
+        let wav = try WAVFile(url: URL(fileURLWithPath: path))
+        return decode(samples: wav.samples, sampleRate: wav.sampleRate)
+    }
+
+    /// Decode a buffer of samples recorded at `sampleRate`.
+    public func decode(samples: [Float], sampleRate: Double) -> String {
+        // Estimate the dominant tone frequency in the 300–1000 Hz range.
+        let tone = estimateFrequency(samples: samples, sampleRate: sampleRate)
+
+        // Break the stream into 10 ms windows and compute the tone power for
+        // each window.  Afterwards apply a short moving average to smooth the
+        // envelope which helps remove spurious transitions.
+        let windowDuration = 0.01 // seconds
+        let windowSize = max(1, Int(sampleRate * windowDuration))
+        var powers: [Float] = []
+        powers.reserveCapacity(samples.count / windowSize)
+        var index = 0
+        while index < samples.count {
+            let end = min(index + windowSize, samples.count)
+            let power = goertzel(Array(samples[index..<end]), tone, sampleRate)
+            powers.append(power)
+            index = end
+        }
+        guard !powers.isEmpty else { return "" }
+
+        var magnitudes: [Float] = []
+        magnitudes.reserveCapacity(powers.count)
+        for i in 0..<powers.count {
+            let start = max(0, i - 2)
+            let end = min(powers.count, i + 3)
+            let slice = powers[start..<end]
+            let avg = slice.reduce(0, +) / Float(slice.count)
+            magnitudes.append(avg)
+        }
+
+        guard let maxMag = magnitudes.max() else { return "" }
+        let threshold = maxMag * 0.3
+        let states = magnitudes.map { $0 > threshold }
+
+        // Compress consecutive states into durations measured in windows.
+        var segments: [(Bool, Int)] = []
+        var current = states.first ?? false
+        var length = 0
+        for state in states {
+            if state == current {
+                length += 1
+            } else {
+                segments.append((current, length))
+                current = state
+                length = 1
+            }
+        }
+        segments.append((current, length))
+
+        // Determine the basic time unit T (length of a dot). Use the 33rd
+        // percentile of keyed segments (ignoring very short blips) for a robust
+        // estimate.
+        let keyedLengths = segments.filter { $0.0 && $0.1 >= 3 }.map { $0.1 }.sorted()
+        let unit: Int
+        if keyedLengths.isEmpty {
+            unit = 1
+        } else {
+            unit = keyedLengths[keyedLengths.count / 3]
+        }
+
+        // Merge segments shorter than half a unit into their predecessor and
+        // collapse consecutive segments of the same state.
+        let minLen = max(1, unit / 2)
+        var cleaned: [(Bool, Int)] = []
+        for seg in segments {
+            if seg.1 < minLen {
+                if let last = cleaned.last {
+                    cleaned[cleaned.count - 1].1 = last.1 + seg.1
+                }
+            } else {
+                if let last = cleaned.last, last.0 == seg.0 {
+                    cleaned[cleaned.count - 1].1 = last.1 + seg.1
+                } else {
+                    cleaned.append(seg)
+                }
+            }
+        }
+        segments = cleaned
+
+        var result = ""
+        var symbol = ""
+        func flushSymbol() {
+            if !symbol.isEmpty {
+                if let char = morseToChar[symbol] {
+                    result.append(char)
+                } else {
+                    result.append("?")
+                }
+                symbol.removeAll()
+            }
+        }
+
+        for seg in segments {
+            if seg.0 { // keyed (tone present)
+                if seg.1 < 2 * unit {
+                    symbol.append(".")
+                } else {
+                    symbol.append("-")
+                }
+            } else { // unkeyed (silence)
+                if seg.1 >= 6 * unit {
+                    flushSymbol()
+                    result.append(" ")
+                } else if seg.1 >= 3 * unit {
+                    flushSymbol()
+                }
+            }
+        }
+        flushSymbol()
+
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Estimate the dominant tone frequency in the given sample buffer.
+    private func estimateFrequency(samples: [Float], sampleRate: Double) -> Double {
+        var bestFreq: Double = 600
+        var bestPower: Float = -Float.greatestFiniteMagnitude
+        var freq: Double = 300
+        while freq <= 1000 {
+            let power = goertzel(samples, freq, sampleRate)
+            if power > bestPower {
+                bestPower = power
+                bestFreq = freq
+            }
+            freq += 10
+        }
+        return bestFreq
+    }
+
+    /// Power computation for a specific tone using the Goertzel algorithm.
+    private func goertzel(_ samples: [Float], _ targetFrequency: Double, _ sampleRate: Double) -> Float {
+        let normalizedFrequency = targetFrequency / sampleRate
+        let coeff = 2.0 * cos(2.0 * Double.pi * normalizedFrequency)
+        var sPrev: Double = 0
+        var sPrev2: Double = 0
+        for sample in samples {
+            let s = Double(sample) + coeff * sPrev - sPrev2
+            sPrev2 = sPrev
+            sPrev = s
+        }
+        let power = sPrev2 * sPrev2 + sPrev * sPrev - coeff * sPrev * sPrev2
+        return Float(power)
+    }
+
+    /// Mapping from dot/dash sequences to characters.
+    private let morseToChar: [String: String] = [
+        ".-": "A", "-...": "B", "-.-.": "C", "-..": "D", ".": "E", "..-.": "F",
+        "--.": "G", "....": "H", "..": "I", ".---": "J", "-.-": "K", ".-..": "L",
+        "--": "M", "-.": "N", "---": "O", ".--.": "P", "--.-": "Q", ".-.": "R",
+        "...": "S", "-": "T", "..-": "U", "...-": "V", ".--": "W", "-..-": "X",
+        "-.--": "Y", "--..": "Z", "-----": "0", ".----": "1", "..---": "2",
+        "...--": "3", "....-": "4", ".....": "5", "-....": "6", "--...": "7",
+        "---..": "8", "----.": "9"
+    ]
+}
+

--- a/Sources/cw/DiscoverDevices.swift
+++ b/Sources/cw/DiscoverDevices.swift
@@ -1,3 +1,9 @@
+import Foundation
+
+/// Print a list of available input audio devices.  The real implementation is
+/// only available on macOS where CoreAudio can be used.  On other platforms this
+/// function simply informs the user that the operation is unsupported.
+#if os(macOS)
 import CoreAudio
 
 public func listAudioDevices() {
@@ -11,7 +17,7 @@ public func listAudioDevices() {
     let deviceCount = Int(size) / MemoryLayout<AudioDeviceID>.size
     var devices = [AudioDeviceID](repeating: 0, count: deviceCount)
     AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &devices)
-    
+
     for (index, device) in devices.enumerated() {
         var name: CFString = "" as CFString
         var nameSize = UInt32(MemoryLayout<CFString>.size)
@@ -25,4 +31,12 @@ public func listAudioDevices() {
         print("Device \(index): \(deviceName)")
     }
 }
+
+#else
+
+public func listAudioDevices() {
+    print("Audio device listing is not supported on this platform")
+}
+
+#endif
 

--- a/Sources/cw/DiscoverDevices.swift
+++ b/Sources/cw/DiscoverDevices.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// Print a list of available input audio devices.  The real implementation is
-/// only available on macOS where CoreAudio can be used.  On other platforms this
-/// function simply informs the user that the operation is unsupported.
-#if os(macOS)
+#if canImport(CoreAudio)
 import CoreAudio
 
 public func listAudioDevices() {
@@ -31,12 +28,8 @@ public func listAudioDevices() {
         print("Device \(index): \(deviceName)")
     }
 }
-
 #else
-
 public func listAudioDevices() {
-    print("Audio device listing is not supported on this platform")
+    print("Audio device listing is not supported on this platform.")
 }
-
 #endif
-

--- a/Sources/cw/WAVFile.swift
+++ b/Sources/cw/WAVFile.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Minimal WAV (RIFF) reader supporting 16‑bit PCM mono files.  It is sufficient
+/// for loading the bundled test samples without relying on platform specific
+/// audio frameworks.
+struct WAVFile {
+    let sampleRate: Double
+    let samples: [Float]
+
+    init(url: URL) throws {
+        let data = try Data(contentsOf: url)
+        guard data.count > 44 else {
+            throw NSError(domain: "WAVFile", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "File too small to be a WAV file"])
+        }
+
+        func readUInt32(_ offset: Int) -> UInt32 {
+            let range = offset..<(offset + 4)
+            return data.subdata(in: range).withUnsafeBytes { $0.load(as: UInt32.self) }.littleEndian
+        }
+
+        func readUInt16(_ offset: Int) -> UInt16 {
+            let range = offset..<(offset + 2)
+            return data.subdata(in: range).withUnsafeBytes { $0.load(as: UInt16.self) }.littleEndian
+        }
+
+        // Basic RIFF/WAVE validation
+        let riff = String(bytes: data[0..<4], encoding: .ascii)
+        let wave = String(bytes: data[8..<12], encoding: .ascii)
+        guard riff == "RIFF", wave == "WAVE" else {
+            throw NSError(domain: "WAVFile", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid WAV file header"])
+        }
+
+        var offset = 12
+        var foundData = false
+        var dataOffset = 0
+        var dataSize = 0
+        var sampleRate: Int = 0
+        var bitsPerSample: Int = 0
+        var channels: Int = 0
+
+        while offset + 8 <= data.count {
+            let chunkID = String(bytes: data[offset..<(offset + 4)], encoding: .ascii)
+            let chunkSize = Int(readUInt32(offset + 4))
+            if chunkID == "fmt " {
+                channels = Int(readUInt16(offset + 10))
+                sampleRate = Int(readUInt32(offset + 12))
+                bitsPerSample = Int(readUInt16(offset + 22))
+            } else if chunkID == "data" {
+                dataOffset = offset + 8
+                dataSize = chunkSize
+                foundData = true
+                break
+            }
+            offset += 8 + chunkSize + (chunkSize % 2)
+        }
+
+        guard foundData else {
+            throw NSError(domain: "WAVFile", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey: "WAV file missing data chunk"])
+        }
+
+        let bytesPerSample = bitsPerSample / 8
+        let totalSamples = dataSize / bytesPerSample / max(channels, 1)
+        var result: [Float] = []
+        result.reserveCapacity(totalSamples)
+
+        for i in 0..<totalSamples {
+            let start = dataOffset + i * bytesPerSample * max(channels, 1)
+            switch bitsPerSample {
+            case 16:
+                let value = Int16(littleEndian: data.subdata(in: start..<(start + 2)).withUnsafeBytes { $0.load(as: Int16.self) })
+                result.append(Float(value) / Float(Int16.max))
+            default:
+                throw NSError(domain: "WAVFile", code: 4,
+                              userInfo: [NSLocalizedDescriptionKey: "Unsupported bit depth: \(bitsPerSample)"])
+            }
+        }
+
+        self.sampleRate = Double(sampleRate)
+        self.samples = result
+    }
+}
+

--- a/Tests/analyzeSamplesTests.swift
+++ b/Tests/analyzeSamplesTests.swift
@@ -14,3 +14,4 @@ import Foundation
     let text = try decoder.decodeWAVFile(atPath: url.path)
     #expect(text == "CQ CQ CQ DE W2ASM K")
 }
+

--- a/Tests/analyzeSamplesTests.swift
+++ b/Tests/analyzeSamplesTests.swift
@@ -2,24 +2,14 @@ import Testing
 import Foundation
 @testable import cw
 
-@Test func testAnalyzeSamples() throws {
-    let fileManager = FileManager.default
-    let samplesDirectory = "./Tests/samples"
-
-    do {
-        let files = try fileManager.contentsOfDirectory(atPath: samplesDirectory)
-        for file in files {
-            print("Found file: \(file)")
-
-            let queue = DispatchQueue(label: "com.example.audioStreamerTest")
-            queue.async {
-                let audio = AudioStreamer()
-                audio.startStreamingFile(fromPath: "\(samplesDirectory)/\(file)")
-                RunLoop.current.run()
-            }
-            break
-        }
-    } catch {
-        #expect(Bool(false), "Failed to list files in directory: \(error)")
-    }
+/// Verify that the decoder can recover the expected text from one of the
+/// bundled sample recordings.
+@Test func testDecodeSample() throws {
+    let decoder = CWDecoder()
+    let url = Bundle.module.url(forResource: "sample_12_600_10_CQ_CQ_CQ_DE_W2ASM_K",
+                                withExtension: "wav",
+                                subdirectory: "samples")!
+    let text = try decoder.decodeWAVFile(atPath: url.path)
+    #expect(text == "CQ CQ CQ DE W2ASM K")
 }
+

--- a/Tests/analyzeSamplesTests.swift
+++ b/Tests/analyzeSamplesTests.swift
@@ -6,10 +6,11 @@ import Foundation
 /// bundled sample recordings.
 @Test func testDecodeSample() throws {
     let decoder = CWDecoder()
-    let url = Bundle.module.url(forResource: "sample_12_600_10_CQ_CQ_CQ_DE_W2ASM_K",
-                                withExtension: "wav",
-                                subdirectory: "samples")!
+    let url = Bundle.module.url(
+        forResource: "sample_12_600_10_CQ_CQ_CQ_DE_W2ASM_K",
+        withExtension: "wav",
+        subdirectory: "samples"
+    )!
     let text = try decoder.decodeWAVFile(atPath: url.path)
     #expect(text == "CQ CQ CQ DE W2ASM K")
 }
-


### PR DESCRIPTION
## Summary
- Implement cross-platform audio streaming with a simple FileStreamer and optional macOS device streamer
- Add minimal WAV parser and CWDecoder to detect tone frequency, segment timing and decode Morse to text
- Test decoding on provided sample recording

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689cc98d238c832c8669c25441120152